### PR TITLE
Test on PHP 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.0', '8.1']
+                php: ['8.0', '8.1', '8.2']
                 psrlog: ['^1.0', '^2.0', '^3.0']
                 stable: [true]
                 coverage: [true]


### PR DESCRIPTION
We're close enough to the 8.2.0 release to consider it "stable" for testing purposes.