### PR TITLE
feat: remove requirement to pass a level

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ hasNotice(string|array $record): bool
 hasInfo(string|array $record): bool
 hasDebug(string|array $record): bool
 
-hasRecordThatContains(string $message, string|int $level): bool
+hasRecordThatContains(string $message, string|int|null $level = null): bool
 
 hasEmergencyThatContains(string $message): bool
 hasAlertThatContains(string $message): bool
@@ -57,7 +57,7 @@ hasNoticeThatContains(string $message): bool
 hasInfoThatContains(string $message): bool
 hasDebugThatContains(string $message): bool
 
-hasRecordThatMatches(string $regex, string|int $level): bool
+hasRecordThatMatches(string $regex, string|int|null $level = null): bool
 
 hasEmergencyThatMatches(string $regex): bool
 hasAlertThatMatches(string $regex): bool
@@ -68,7 +68,7 @@ hasNoticeThatMatches(string $regex): bool
 hasInfoThatMatches(string $regex): bool
 hasDebugThatMatches(string $regex): bool
 
-hasRecordThatPasses(callable $predicate, string|int $level): bool
+hasRecordThatPasses(callable $predicate, string|int|null $level = null): bool
 
 hasEmergencyThatPasses(callable $predicate): bool
 hasAlertThatPasses(callable $predicate): bool

--- a/src/TestLogger.php
+++ b/src/TestLogger.php
@@ -86,15 +86,19 @@ final class TestLogger extends AbstractLogger
         $this->records[]                          = $record;
     }
 
-    public function hasRecords(string|int $level): bool
+    public function hasRecords(string|int|null $level = null): bool
     {
+        if ($level === null) {
+            return \count($this->records) !== 0;
+        }
+
         return isset($this->recordsByLevel[$level]);
     }
 
     /**
      * @param string|array<string, mixed> $record
      */
-    public function hasRecord(string|array $record, string|int $level): bool
+    public function hasRecord(string|array $record, string|int|null $level = null): bool
     {
         if (\is_string($record)) {
             $record = ['message' => $record];
@@ -109,14 +113,14 @@ final class TestLogger extends AbstractLogger
         }, $level);
     }
 
-    public function hasRecordThatContains(string $message, string|int $level): bool
+    public function hasRecordThatContains(string $message, string|int|null $level = null): bool
     {
         return $this->hasRecordThatPasses(static function (array $rec) use ($message) {
             return \str_contains($rec['message'], $message);
         }, $level);
     }
 
-    public function hasRecordThatMatches(string $regex, string|int $level): bool
+    public function hasRecordThatMatches(string $regex, string|int|null $level = null): bool
     {
         return $this->hasRecordThatPasses(static function ($rec) use ($regex) {
             return \preg_match($regex, $rec['message']) > 0;
@@ -126,13 +130,13 @@ final class TestLogger extends AbstractLogger
     /**
      * @param callable(array<string, mixed>, int): bool $predicate
      */
-    public function hasRecordThatPasses(callable $predicate, string|int $level): bool
+    public function hasRecordThatPasses(callable $predicate, string|int|null $level = null): bool
     {
-        if (! isset($this->recordsByLevel[$level])) {
+        if (! $this->hasRecords($level)) {
             return false;
         }
 
-        foreach ($this->recordsByLevel[$level] as $i => $rec) {
+        foreach ($level === null ? $this->records : $this->recordsByLevel[$level] as $i => $rec) {
             if (\call_user_func($predicate, $rec, $i)) {
                 return true;
             }

--- a/tests/unit/TestLoggerTest.php
+++ b/tests/unit/TestLoggerTest.php
@@ -14,15 +14,15 @@ final class TestLoggerTest extends TestCase
     /**
      * @dataProvider provideLogLevels
      */
-    public function testHasRecords(string $level): void
+    public function testHasRecords(string|null $level): void
     {
-        $magicMethod = 'has' . \ucfirst($level) . 'Records';
+        $magicMethod = 'has' . \ucfirst($level ?? '') . 'Records';
 
         $logger = new TestLogger();
         $this->assertFalse($logger->hasRecords($level));
         $this->assertFalse($logger->$magicMethod());
 
-        $logger->log($level, 'Test');
+        $logger->log($level ?? LogLevel::INFO, 'Test');
         $this->assertTrue($logger->hasRecords($level));
         $this->assertTrue($logger->$magicMethod());
     }
@@ -30,9 +30,9 @@ final class TestLoggerTest extends TestCase
     /**
      * @dataProvider provideLogLevels
      */
-    public function testHasRecord(string $level): void
+    public function testHasRecord(string|null $level): void
     {
-        $magicMethod = 'has' . \ucfirst($level);
+        $magicMethod = 'has' . \ucfirst($level ?? 'Record');
 
         $logger = new TestLogger();
         $this->assertFalse($logger->hasRecord('Test', $level));
@@ -40,7 +40,7 @@ final class TestLoggerTest extends TestCase
         $this->assertFalse($logger->$magicMethod('Test'));
         $this->assertFalse($logger->$magicMethod(['message' => 'Test']));
 
-        $logger->log($level, 'Test');
+        $logger->log($level ?? LogLevel::INFO, 'Test');
 
         $this->assertTrue($logger->hasRecord('Test', $level));
         $this->assertTrue($logger->hasRecord(['message' => 'Test'], $level));
@@ -56,15 +56,15 @@ final class TestLoggerTest extends TestCase
     /**
      * @dataProvider provideLogLevels
      */
-    public function testHasRecordThatContains(string $level): void
+    public function testHasRecordThatContains(string|null $level): void
     {
-        $magicMethod = 'has' . \ucfirst($level) . 'ThatContains';
+        $magicMethod = 'has' . \ucfirst($level ?? 'Record') . 'ThatContains';
 
         $logger = new TestLogger();
         $this->assertFalse($logger->hasRecordThatContains('Test', $level));
         $this->assertFalse($logger->$magicMethod('Test'));
 
-        $logger->log($level, 'This Is A Test');
+        $logger->log($level ?? LogLevel::INFO, 'This Is A Test');
 
         $this->assertTrue($logger->hasRecordThatContains('Test', $level));
         $this->assertTrue($logger->$magicMethod('Test'));
@@ -73,15 +73,15 @@ final class TestLoggerTest extends TestCase
     /**
      * @dataProvider provideLogLevels
      */
-    public function testHasRecordThatMatches(string $level): void
+    public function testHasRecordThatMatches(string|null $level): void
     {
-        $magicMethod = 'has' . \ucfirst($level) . 'ThatMatches';
+        $magicMethod = 'has' . \ucfirst($level ?? 'Record') . 'ThatMatches';
 
         $logger = new TestLogger();
         $this->assertFalse($logger->hasRecordThatMatches('/test/i', $level));
         $this->assertFalse($logger->$magicMethod('/test/i'));
 
-        $logger->log($level, 'This Is A Test');
+        $logger->log($level ?? LogLevel::INFO, 'This Is A Test');
 
         $this->assertTrue($logger->hasRecordThatMatches('/test/i', $level));
         $this->assertTrue($logger->$magicMethod('/test/i'));
@@ -90,9 +90,9 @@ final class TestLoggerTest extends TestCase
     /**
      * @dataProvider provideLogLevels
      */
-    public function testHasRecordThatPasses(string $level): void
+    public function testHasRecordThatPasses(string|null $level): void
     {
-        $magicMethod = 'has' . \ucfirst($level) . 'ThatPasses';
+        $magicMethod = 'has' . \ucfirst($level ?? 'Record') . 'ThatPasses';
 
         $logger = new TestLogger();
         $this->assertFalse($logger->hasRecordThatPasses(static function ($record) {
@@ -102,7 +102,7 @@ final class TestLoggerTest extends TestCase
             return $record['message'] === 'Test';
         }));
 
-        $logger->log($level, 'Test');
+        $logger->log($level ?? LogLevel::INFO, 'Test');
 
         $this->assertTrue($logger->hasRecordThatPasses(static function ($record) {
             return $record['message'] === 'Test';
@@ -211,5 +211,6 @@ final class TestLoggerTest extends TestCase
         yield [LogLevel::CRITICAL];
         yield [LogLevel::ALERT];
         yield [LogLevel::EMERGENCY];
+        yield [null];
     }
 }


### PR DESCRIPTION
To allow a quick and dirty way to check the logs:

```php
$logger->hasRecords();
$logger->hasRecord('Test');
$logger->hasRecordThatContains('Test');
$logger->hasRecordThatMatches('...');
$logger->hasRecordThatPasses(...);
```