### PR TITLE
ci: add tests for PHP 8.4 and 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v5
 
             - uses: shivammathur/setup-php@v2
               with:
@@ -29,14 +29,14 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.0', '8.1', '8.2', '8.3']
+                php: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
                 psrlog: ['^1.0', '^2.0', '^3.0']
                 stable: [true]
                 coverage: [true]
                 composer-flags: ['', '--prefer-lowest']
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v5
               with:
                 fetch-depth: 0
 
@@ -65,7 +65,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v5
 
             - uses: shivammathur/setup-php@v2
               with:
@@ -82,7 +82,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v5
 
             - uses: shivammathur/setup-php@v2
               with:


### PR DESCRIPTION
Upgrade actions/checkout from v2 to v5

vimeo/psalm will possibly be a blocker. maybe more