### PR TITLE
Fix phpstan failure

### DIFF
--- a/src/TestLogger.php
+++ b/src/TestLogger.php
@@ -68,6 +68,7 @@ final class TestLogger extends AbstractLogger
     /**
      * {@inheritDoc}
      *
+     * @param mixed                   $message
      * @param array<array-key, mixed> $context
      */
     public function log($level, $message, array $context = []): void


### PR DESCRIPTION
Add a `@param` specifying that `$message` intentionally accepts `mixed`